### PR TITLE
Fix https://bz.apache.org/bugzilla/show_bug.cgi?id=63724

### DIFF
--- a/java/org/apache/jasper/compiler/JspUtil.java
+++ b/java/org/apache/jasper/compiler/JspUtil.java
@@ -742,8 +742,8 @@ public class JspUtil {
         String classNameComponents[] = path.split("/");
         StringBuilder legalClassNames = new StringBuilder();
         for (int i = 0; i < classNameComponents.length; i++) {
-            if(0 < classNameComponents[i].length()) {
-                if(0 < i) {
+            if (classNameComponents[i].length() > 0) {
+                if (legalClassNames.length() > 0) {
                     legalClassNames.append('.');
                 }
                 legalClassNames.append(makeJavaIdentifier(classNameComponents[i]));

--- a/test/org/apache/jasper/compiler/TestJspUtilMakeJavaPackage.java
+++ b/test/org/apache/jasper/compiler/TestJspUtilMakeJavaPackage.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jasper.compiler;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+@RunWith(Parameterized.class)
+public class TestJspUtilMakeJavaPackage {
+
+    @Parameterized.Parameters(name = "{index}: input[{0}], expected [{1}]")
+    public static Collection<Object[]> parameters() {
+        List<Object[]> parameterSets = new ArrayList<>();
+
+        parameterSets.add(new Object[] { "/foo", "foo"});
+        parameterSets.add(new Object[] { "//foo", "foo"});
+        parameterSets.add(new Object[] { "//foo//", "foo"});
+        parameterSets.add(new Object[] { "/foo//", "foo"});
+        parameterSets.add(new Object[] { "/foo/", "foo"});
+        parameterSets.add(new Object[] { "foo/", "foo"});
+
+        parameterSets.add(new Object[] { "/foo/bar", "foo.bar"});
+        parameterSets.add(new Object[] { "//foo/bar", "foo.bar"});
+        parameterSets.add(new Object[] { "//foo//bar", "foo.bar"});
+        parameterSets.add(new Object[] { "/foo//bar", "foo.bar"});
+        parameterSets.add(new Object[] { "/foo/bar", "foo.bar"});
+        parameterSets.add(new Object[] { "foo/bar", "foo.bar"});
+
+        return parameterSets;
+    }
+
+    @Parameter(0)
+    public String input;
+
+    @Parameter(1)
+    public String expected;
+
+    @Test
+    public void doTest() {
+        Assert.assertEquals(expected, JspUtil.makeJavaPackage(input));
+    }
+}

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -83,6 +83,14 @@
       </fix>
     </changelog>
   </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>63724</bug>: Correct a regression introduced in 9.0.21 that broke
+        compilation of JSPs in some configurations. (markt)
+      </fix>
+    </changelog>
+  </subsection>
   <subsection name="Web applications">
     <changelog>
       <fix>


### PR DESCRIPTION
Correct a regression introduced in 9.0.21 that broke compilation of JSPs
in some configurations.